### PR TITLE
Clean db on deploy

### DIFF
--- a/DB/createUsersTable.py
+++ b/DB/createUsersTable.py
@@ -26,4 +26,4 @@ table = dynamodb.create_table(
     }
 )
 
-print("Table status:", table.table_status)
+print("Users Table:", table.table_status)

--- a/DB/createUsersTable.py
+++ b/DB/createUsersTable.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+from __future__ import print_function # Python 2/3 compatibility
+import boto3
+
+dynamodb = boto3.resource('dynamodb', region_name='us-west-2')
+
+
+table = dynamodb.create_table(
+    TableName='users',
+    KeySchema=[
+        {
+            'AttributeName': 'email',
+            'KeyType': 'HASH'  #Partition key
+        }
+    ],
+    AttributeDefinitions=[
+        {
+            'AttributeName': 'email',
+            'AttributeType': 'S'
+        }
+    ],
+    ProvisionedThroughput={
+        'ReadCapacityUnits': 1,
+        'WriteCapacityUnits': 1
+    }
+)
+
+print("Table status:", table.table_status)

--- a/DB/deleteAllDbTables.py
+++ b/DB/deleteAllDbTables.py
@@ -6,17 +6,11 @@ import boto3
 dynamodb = boto3.resource('dynamodb', region_name='us-west-2')
 client = boto3.client('dynamodb')
 
-
-#table = dynamodb.Table('Movies')
-
-#table.delete()
-
 tables = client.list_tables()
 tableNames = tables['TableNames']
-print (tableNames)
 
 for i in tableNames:
-  print (i)
+  print ("Deleting " + i + "table")
   table = dynamodb.Table(i)
 
   table.delete()

--- a/DB/deleteAllDbTables.py
+++ b/DB/deleteAllDbTables.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from __future__ import print_function # Python 2/3 compatibility
+import boto3
+
+dynamodb = boto3.resource('dynamodb', region_name='us-west-2')
+client = boto3.client('dynamodb')
+
+
+#table = dynamodb.Table('Movies')
+
+#table.delete()
+
+tables = client.list_tables()
+tableNames = tables['TableNames']
+print (tableNames)
+
+for i in tableNames:
+  print (i)
+  table = dynamodb.Table(i)
+
+  table.delete()

--- a/build.sh
+++ b/build.sh
@@ -219,8 +219,8 @@ finishBuild() {
   rm -rf $mentii_repo_dir
 
   # Sends slack message saying build is done
-  local message="Build Complete at $currentDateEST. Latest commit on $gitBranch: $gitBranchLastCommit"
   updateCurrentDateEST
+  local message="Build Complete at $currentDateEST. Latest commit on $gitBranch: $gitBranchLastCommit"
   sendSlackNotification $message
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -59,7 +59,7 @@ then
     exit 3
 fi
 
-# Notify slack that the 
+# Notify slack that the deploy has finished
 echo "SENDING SLACK NOTIFICATION"
 date=`TZ="America/New_York" date`
 /home/ec2-user/slackNotify.sh "Deploy Complete at $date."

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+## Locations
 home_dir='/home/ec2-user'
 mentii_repo_dir="$home_dir/mentii"
 builds_dir="$home_dir/builds"
 build_scripts_dir="$home_dir/BuildScripts"
 
-#wget the tar file from the build server
+# Wget the tar file from the build server
 echo "GETTING THE TAR FILE FROM TUX"
 cd $builds_dir
 if ! wget --no-verbose -O new.build.tar https://cs.drexel.edu/~asp78/builds/build.tar
@@ -18,25 +19,24 @@ then
 fi
 mv --backup=numbered new.build.tar build.tar
 
-#remove the current mentii directory
+# Remove the current mentii directory
 echo "DELETING THE CURRENT MENTII REPOISTORY"
 rm -rf $mentii_repo_dir
 
-#Delete Current DBs and recreate tables
+# Delete Current DBs table and recreate them fresh
 echo "DELETING THE DB TABLES"
 $build_scripts_dir/DB/deleteAllDbTables.py
 sleep 3 # needed for sync time to amazon
+
 echo "CREATING DB TABLES"
 $build_scripts_dir/DB/createUsersTable.py
 
-exit 0
-
-#untar the tar from the build server
+# Untar the tar from the build server
 echo "UNTARING THE FILE"
 cd $home_dir
 tar -xf $builds_dir/build.tar
 
-#Make deploy
+# Make deploy
 echo "DEPLOYING THE APPLICATION"
 cd $mentii_repo_dir
 if ! make deploy
@@ -48,7 +48,7 @@ then
     exit 2
 fi
 
-#Restart the server
+# Restart the server
 echo "RESTARTING THE SERVER"
 if ! sudo service httpd restart
 then
@@ -59,7 +59,7 @@ then
     exit 3
 fi
 
-#Notify slack that the 
+# Notify slack that the 
 echo "SENDING SLACK NOTIFICATION"
 date=`TZ="America/New_York" date`
 /home/ec2-user/slackNotify.sh "Deploy Complete at $date."

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,6 +3,7 @@
 home_dir='/home/ec2-user'
 mentii_repo_dir="$home_dir/mentii"
 builds_dir="$home_dir/builds"
+build_scripts_dir="$home_dir/BuildScripts"
 
 #wget the tar file from the build server
 echo "GETTING THE TAR FILE FROM TUX"
@@ -20,6 +21,10 @@ mv --backup=numbered new.build.tar build.tar
 #remove the current mentii directory
 echo "DELETING THE CURRENT MENTII REPOISTORY"
 rm -rf $mentii_repo_dir
+
+#Delete Current DBs and recreate tables
+./$build_scripts_dir/DB/deleteAllDbTables.py
+./$build_scripts_dir/DB/createUsersTable.py
 
 #untar the tar from the build server
 echo "UNTARING THE FILE"

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,8 +23,13 @@ echo "DELETING THE CURRENT MENTII REPOISTORY"
 rm -rf $mentii_repo_dir
 
 #Delete Current DBs and recreate tables
-./$build_scripts_dir/DB/deleteAllDbTables.py
-./$build_scripts_dir/DB/createUsersTable.py
+echo "DELETING THE DB TABLES"
+$build_scripts_dir/DB/deleteAllDbTables.py
+sleep 3 # needed for sync time to amazon
+echo "CREATING DB TABLES"
+$build_scripts_dir/DB/createUsersTable.py
+
+exit 0
 
 #untar the tar from the build server
 echo "UNTARING THE FILE"


### PR DESCRIPTION
So now when deploys happen we remove all db tables and put back the ones that belong. This also fixes the build script time for completion.